### PR TITLE
Remove option to configure schema name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Error checking and warning when schema is not working
+
+### Removed
+- Option to configure the schema name
 
 ## [0.1.0] - 2018-11-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1] - 2018-11-05
 ### Added
 - Error checking and warning when schema is not working
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This app shows the last order for the identified user, with a button to buy the 
 
 For this to work, you need to create the `lastOrders` schema on the `orders` dataentity. [Docs](http://help.vtex.com/en/tutorial/master-data-v2)
 
-If you have a schema with a different name, change the configuration for Rebuy in `https://{{account}}.myvtex.com/admin/apps`.
-
 ```json
 {
   "properties": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "rebuy",
   "vendor": "vtex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "title": "Rebuy",
   "description": "VTEX Rebuy app",
   "mustUpdateAt": "2019-10-26",

--- a/react/components/Rebuy.js
+++ b/react/components/Rebuy.js
@@ -42,14 +42,25 @@ class Rebuy extends Component {
 
   render() {
     const {
-      fetchContext: { loading, data },
+      fetchContext: { data, error, loading },
     } = this.props
     const { isAddingToCart } = this.state
 
-    if (loading) return <Spinner />
+    if (loading) {
+      return <Spinner />
+    }
+    
+    if (error >= 400) {
+      console.warn(
+        'The "lastOrders" schema seems to be missing. Create it according to the instruction on README.'
+      )
+      return null
+    }
 
     const lastOrder = head(data)
-    if (!lastOrder) return null
+    if (!lastOrder) {
+      return null
+    }
 
     return (
       <section className="vtex-rebuy vtex-page-padding">

--- a/react/components/withFetch.js
+++ b/react/components/withFetch.js
@@ -8,12 +8,15 @@ const withFetch = WrappedComponent =>
       url: string.isRequired,
       children: func.isRequired,
     }
-    state = { loading: true, data: null }
+    state = { loading: true, data: null, error: null }
 
     async componentDidMount() {
       const { url } = this.props
-      const response = await fetch(url).then(response => response.json())
-      this.setState({ data: response, loading: false })
+      const response = await fetch(url)
+      if (!response.ok) {
+        return this.setState({ data: [], error: response.status, loading: false})
+      }
+      this.setState({ data: await response.json(), error: null, loading: false })
     }
 
     render() {

--- a/react/index.js
+++ b/react/index.js
@@ -1,10 +1,8 @@
 import React, { Component } from 'react'
-import { func } from 'prop-types'
 import { path } from 'ramda'
 import { Spinner } from 'vtex.styleguide'
 import { orderFormConsumer, contextPropTypes } from 'vtex.store/OrderFormContext'
 
-import pkg from './package.json'
 import Rebuy from './components/Rebuy'
 
 import './global.css'
@@ -14,20 +12,12 @@ import './global.css'
  */
 class RebuyContainer extends Component {
   static propTypes = { orderFormContext: contextPropTypes }
-  static contextTypes = { getSettings: func }
-
-  get settings() {
-    const { schemaName = 'lastOrders', ...settings } = this.context.getSettings(
-      `${pkg.vendor}.${pkg.name}`
-    )
-    return { schemaName, ...settings }
-  }
+  schemaName = 'lastOrders'
 
   getOrdersURL = ({ schemaName, email }) =>
-    `/api/dataentities/orders/search?_schema=${schemaName}&_where=clientProvileData.email=${email}&_sort=createdIn DESC`
+    `/api/dataentities/orders/search?_schema=${schemaName}&_where=clientProfileData.email=${email}&_sort=createdIn DESC`
 
   render() {
-    const { schemaName } = this.settings
     const { loading, orderForm } = this.props.orderFormContext
 
     if (loading) return <Spinner />
@@ -35,7 +25,7 @@ class RebuyContainer extends Component {
     const email = path(['clientProfileData', 'email'], orderForm)
     if (!email) return null
 
-    const ordersURL = this.getOrdersURL({ schemaName, email })
+    const ordersURL = this.getOrdersURL({ schemaName: this.schemaName, email })
 
     return <Rebuy url={ordersURL} {...this.props} />
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove settings that allowed to setup a name for the schema to query orders with, and now it explicitly gets `lastOrders` schema and warns on console if the API returns a 400 and up error.
Also fixes typo on the URL.

#### Screenshots or example usage
![screenshot at oct 31 17-57-30](https://user-images.githubusercontent.com/27775611/48020834-0a20f280-e11e-11e8-8534-4b7ad1db4df5.png)

#### Types of changes
* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.